### PR TITLE
Surface.emit should check event before doing event.stopPropogation

### DIFF
--- a/Surface.js
+++ b/Surface.js
@@ -98,13 +98,13 @@ define(function(require, exports, module) {
      * @method emit
      *
      * @param {string} type event type key (for example, 'click')
-     * @param {Object} event event data
+     * @param {Object} [event] event data
      * @return {EventHandler} this
      */
     Surface.prototype.emit = function emit(type, event) {
         if (event && !event.origin) event.origin = this;
         var handled = this.eventHandler.emit(type, event);
-        if (handled && event.stopPropagation) event.stopPropagation();
+        if (handled && event && event.stopPropagation) event.stopPropagation();
         return handled;
     };
 


### PR DESCRIPTION
I expected emit to allow just a type to be passed.
This is common in other frameworks that have eventing (e.g. ExtJS) where the event can be "the message" without any payload.

The first conditional in this method does if (event && ...)
The second conditional does if (handled && event.stopPropogation)
To support just passing type, it should be if(handled && event && event.stopPropogation).
