### PR TITLE
fixes issue #18

### DIFF
--- a/Surface.js
+++ b/Surface.js
@@ -12,7 +12,7 @@ define(function(require, exports, module) {
     var EventHandler = require('./EventHandler');
     var Transform = require('./Transform');
 
-    var usePrefix = document.body.style.webkitTransform !== undefined;
+    var usePrefix = document.createElement('div').style.webkitTransform !== undefined;
 
     /**
      * A base class for viewable content and event


### PR DESCRIPTION
I've experienced that Surface fails due to the webkit transform test at
https://github.com/Famous/core/blob/master/Surface.js#L15 - This is the
case when loading scripts before body is created.

We could change it to something like:

``` js
var usePrefix = document.createElement('div').style.webkitTransform !==
undefined;
```
