### PR TITLE
Prevent thrashing of Surface scale values

### DIFF
--- a/Surface.js
+++ b/Surface.js
@@ -316,12 +316,15 @@ define(function(require, exports, module) {
      * @return {string} matrix3d CSS style representation of the transform
      */
     function _formatCSSTransform(m) {
+        m[0] = Math.round(m[0] * 1e6) / 1e6;
+        m[5] = Math.round(m[5] * 1e6) / 1e6;
+
         m[12] = Math.round(m[12] * devicePixelRatio) / devicePixelRatio;
         m[13] = Math.round(m[13] * devicePixelRatio) / devicePixelRatio;
 
         var result = 'matrix3d(';
         for (var i = 0; i < 15; i++) {
-            result += (m[i] < 0.000001 && m[i] > -0.000001) ? '0,' : m[i] + ',';
+            result += (m[i] < 1e-6 && m[i] > -1e-6) ? '0,' : m[i] + ',';
         }
         result += m[15] + ')';
         return result;


### PR DESCRIPTION
A fix was added in 0.1.2 to snap X/Y translation values to the nearest pixel, which partially fixed #15 but I was still seeing the issue with scaled surfaces. This fix rounds X/Y scale values off. I chose a fixed number of decimal places (the magic 1e6 seen throughout the codebase) since scale is a multiplier and can't simply be snapped to the nearest pixel.

This patch resolves #15 for me when watching with the Chrome inspector, although element.style.transform is still being assigned every frame. To skip the assign entirely would probably require a Transform.notApproxEquals() method. I can write this if it sounds like a reasonable approach.
