### PR TITLE
Update position when size changes

### DIFF
--- a/Surface.js
+++ b/Surface.js
@@ -459,7 +459,7 @@ define(function(require, exports, module) {
             target.style.opacity = (opacity >= 1) ? '0.999999' : opacity;
         }
 
-        if (_xyNotEquals(this._origin, origin) || Transform.notEquals(this._matrix, matrix)) {
+        if (_xyNotEquals(this._origin, origin) || Transform.notEquals(this._matrix, matrix) || this._sizeDirty) {
             if (!matrix) matrix = Transform.identity;
             this._matrix = matrix;
             var aaMatrix = matrix;


### PR DESCRIPTION
Update the surface position when the size changes to reflect the origin. before, if you had the origin to something other than default and you change the size then transform it, it would jump.
