### PR TITLE
Remove duplicate check in Transform.notEquals()

### DIFF
--- a/Transform.js
+++ b/Transform.js
@@ -592,7 +592,6 @@ define(function(require, exports, module) {
      */
     Transform.notEquals = function notEquals(a, b) {
         if (a === b) return false;
-        if (!(a && b)) return true;
 
         // shortci
         return !(a && b) ||


### PR DESCRIPTION
`!(a && b)` was being evaluated twice.
