### PR TITLE
Approximate Transform.notEquals()

### DIFF
--- a/Transform.js
+++ b/Transform.js
@@ -596,10 +596,18 @@ define(function(require, exports, module) {
 
         // shortci
         return !(a && b) ||
-            a[12] !== b[12] || a[13] !== b[13] || a[14] !== b[14] ||
-            a[0] !== b[0] || a[1] !== b[1] || a[2] !== b[2] ||
-            a[4] !== b[4] || a[5] !== b[5] || a[6] !== b[6] ||
-            a[8] !== b[8] || a[9] !== b[9] || a[10] !== b[10];
+            Math.abs(a[12] - b[12]) > 1e-5 ||
+            Math.abs(a[13] - b[13]) > 1e-5 ||
+            Math.abs(a[14] - b[14]) > 1e-5 ||
+            Math.abs( a[0] - b[0])  > 1e-5 ||
+            Math.abs( a[1] - b[1])  > 1e-5 ||
+            Math.abs( a[2] - b[2])  > 1e-5 ||
+            Math.abs( a[4] - b[4])  > 1e-5 ||
+            Math.abs( a[5] - b[5])  > 1e-5 ||
+            Math.abs( a[6] - b[6])  > 1e-5 ||
+            Math.abs( a[8] - b[8])  > 1e-5 ||
+            Math.abs( a[9] - b[9])  > 1e-5 ||
+            Math.abs(a[10] - b[10]) > 1e-5;
     };
 
     /**

--- a/Transform.js
+++ b/Transform.js
@@ -599,14 +599,14 @@ define(function(require, exports, module) {
             Math.abs(a[12] - b[12]) > 1e-5 ||
             Math.abs(a[13] - b[13]) > 1e-5 ||
             Math.abs(a[14] - b[14]) > 1e-5 ||
-            Math.abs( a[0] - b[0])  > 1e-5 ||
-            Math.abs( a[1] - b[1])  > 1e-5 ||
-            Math.abs( a[2] - b[2])  > 1e-5 ||
-            Math.abs( a[4] - b[4])  > 1e-5 ||
-            Math.abs( a[5] - b[5])  > 1e-5 ||
-            Math.abs( a[6] - b[6])  > 1e-5 ||
-            Math.abs( a[8] - b[8])  > 1e-5 ||
-            Math.abs( a[9] - b[9])  > 1e-5 ||
+            Math.abs(a[0] - b[0]) > 1e-5 ||
+            Math.abs(a[1] - b[1]) > 1e-5 ||
+            Math.abs(a[2] - b[2]) > 1e-5 ||
+            Math.abs(a[4] - b[4]) > 1e-5 ||
+            Math.abs(a[5] - b[5]) > 1e-5 ||
+            Math.abs(a[6] - b[6]) > 1e-5 ||
+            Math.abs(a[8] - b[8]) > 1e-5 ||
+            Math.abs a[9] - b[9]) > 1e-5 ||
             Math.abs(a[10] - b[10]) > 1e-5;
     };
 

--- a/Transform.js
+++ b/Transform.js
@@ -606,7 +606,7 @@ define(function(require, exports, module) {
             Math.abs(a[5] - b[5]) > 1e-5 ||
             Math.abs(a[6] - b[6]) > 1e-5 ||
             Math.abs(a[8] - b[8]) > 1e-5 ||
-            Math.abs a[9] - b[9]) > 1e-5 ||
+            Math.abs(a[9] - b[9]) > 1e-5 ||
             Math.abs(a[10] - b[10]) > 1e-5;
     };
 


### PR DESCRIPTION
Drops DOM updates during idle in our app to zero. About an 11% JS performance hit in Mobile Safari 7.0 (http://jsperf.com/transform-notequals-absolute-vs-approx), but it has a net effect of a 20% CPU drop during idle in our app.
