### PR TITLE
Improved engine run loop, enable/disable methods and deregisterContext

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -2,8 +2,7 @@
   "requireCurlyBraces": ["do", "try", "catch"],
   "requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return", "try", "catch"],
   "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~", "!"],
-  "requireRightStickedOperators": ["!"],
-  "requireLeftStickedOperators": [","],
+  "disallowSpaceAfterPrefixUnaryOperators": true,
   "disallowKeywords": ["with"],
   "disallowMultipleLineBreaks": true,
   "requireBlocksOnNewline": true,
@@ -11,14 +10,14 @@
   "disallowTrailingWhitespace": true,
   "requireLineFeedAtFileEnd": true,
   "requireSpacesInFunctionExpression": {
-    "beforeOpeningCurlyBrace": true
+      "beforeOpeningCurlyBrace": true
   },
   "disallowSpacesInFunctionExpression": {
       "beforeOpeningRoundBrace": true
   },
   "validateJSDoc": {
-    "checkParamNames": true,
-    "requireParamTypes": false
+      "checkParamNames": true,
+      "requireParamTypes": false
   },
   "validateQuoteMarks": "'",
   "disallowMultipleVarDecl": true,

--- a/.jscsrc
+++ b/.jscsrc
@@ -2,7 +2,8 @@
   "requireCurlyBraces": ["do", "try", "catch"],
   "requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return", "try", "catch"],
   "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~", "!"],
-  "disallowSpaceAfterPrefixUnaryOperators": true,
+  "requireRightStickedOperators": ["!"],
+  "requireLeftStickedOperators": [","],
   "disallowKeywords": ["with"],
   "disallowMultipleLineBreaks": true,
   "requireBlocksOnNewline": true,
@@ -10,14 +11,14 @@
   "disallowTrailingWhitespace": true,
   "requireLineFeedAtFileEnd": true,
   "requireSpacesInFunctionExpression": {
-      "beforeOpeningCurlyBrace": true
+    "beforeOpeningCurlyBrace": true
   },
   "disallowSpacesInFunctionExpression": {
       "beforeOpeningRoundBrace": true
   },
   "validateJSDoc": {
-      "checkParamNames": true,
-      "requireParamTypes": false
+    "checkParamNames": true,
+    "requireParamTypes": false
   },
   "validateQuoteMarks": "'",
   "disallowMultipleVarDecl": true,

--- a/Engine.js
+++ b/Engine.js
@@ -30,7 +30,7 @@ define(function(require, exports, module) {
 
     var Engine = {};
 
-    var timer = window.performance.now.bind(performance) || Date.now;
+    var timer = window.performance.now.bind(window.performance) || Date.now;
     var requestAnimationFrame = window.requestAnimationFrame;
     var cancelAnimationFrame = window.cancelAnimationFrame;
 
@@ -100,13 +100,14 @@ define(function(require, exports, module) {
         // Unless step is true, continue processing frames.
         if (!quantity) {
             requestID = requestAnimationFrame(loop);
-        } else {
+        }
+        else {
             quantity--;
             requestID = requestAnimationFrame(function(timestamp) {
                 loop(timestamp, quantity);
             });
         }
-    };
+    }
 
     /**
      * Enable the Engine step loop.
@@ -117,7 +118,7 @@ define(function(require, exports, module) {
             requestID = requestAnimationFrame(loop);
             loopEnabled = true;
         }
-    }
+    };
 
     /**
      * Disable the Engine step loop.
@@ -129,7 +130,7 @@ define(function(require, exports, module) {
             requestID = undefined;
             loopEnabled = false;
         }
-    }
+    };
 
     Engine.enable();
 
@@ -148,7 +149,7 @@ define(function(require, exports, module) {
         quantity = quantity || 1;
         Engine.disable();
         loop(timer(), quantity);
-    }
+    };
 
     //
     // Upon main document window resize (unless on an "input" HTML element):
@@ -390,7 +391,9 @@ define(function(require, exports, module) {
     optionsManager.on('change', function(data) {
         if (data.id === 'fpsCap') Engine.setFPSCap(data.value);
         else if (data.id === 'runLoop') {
+            /*eslint-disable */
             console.log('Option `runLoop` is deprecated. Use Engine.enable() instead.');
+            /*eslint-enable */
             // kick off the loop only if it was stopped
             if (data.value) {
                 Engine.enable();

--- a/Engine.js
+++ b/Engine.js
@@ -30,7 +30,7 @@ define(function(require, exports, module) {
 
     var Engine = {};
 
-    var timer = performance.now || Date.now;
+    var timer = window.performance.now.bind(performance) || Date.now;
     var requestAnimationFrame = window.requestAnimationFrame;
     var cancelAnimationFrame = window.cancelAnimationFrame;
 
@@ -43,7 +43,7 @@ define(function(require, exports, module) {
     var lastTime = timer();
     var frameTime;
     var frameTimeLimit;
-    var loopEnabled = true;
+    var loopEnabled = false;
     var eventForwarders = {};
     var eventHandler = new EventHandler();
 
@@ -58,8 +58,8 @@ define(function(require, exports, module) {
     var MAX_DEFER_FRAME_TIME = 10;
 
     /**
-     * This is the main loop of the engine, which will schedule itself to be 
-     * called via requestAnimationFrame over and over by defailt. Within it the 
+     * This is the main loop of the engine, which will schedule itself to be
+     * called via requestAnimationFrame over and over by defailt. Within it the
      * following steps take place sequentially:
      *   calculate current FPS (throttling loop if it is over limit set in setFPSCap),
      *   emit dataless 'prerender' event on start of loop,
@@ -68,7 +68,7 @@ define(function(require, exports, module) {
      *   emit dataless 'postrender' event on end of loop.
      *
      * @param  {Number} timestamp High-resolution timestamp passed in by rAF.
-     * @param  {Number} quantity Number of frames to loop through. If false, 
+     * @param  {Number} quantity Number of frames to loop through. If false,
      *                           Engine will loop indefinitely.
      */
     function loop(timestamp, quantity) {
@@ -110,7 +110,7 @@ define(function(require, exports, module) {
 
     /**
      * Enable the Engine step loop.
-     * 
+     *
      */
     Engine.enable = function enable() {
         if (!loopEnabled) {
@@ -121,7 +121,7 @@ define(function(require, exports, module) {
 
     /**
      * Disable the Engine step loop.
-     * 
+     *
      */
     Engine.disable = function disable() {
         if (loopEnabled) {
@@ -134,14 +134,14 @@ define(function(require, exports, module) {
     Engine.enable();
 
     /**
-     * If step() is called, the Engine is disabled and the frame is advanced 
-     * once by default. step() can be called with a quantity to advance the 
+     * If step() is called, the Engine is disabled and the frame is advanced
+     * once by default. step() can be called with a quantity to advance the
      * Engine that many number of frames.
      *
      * @static
      * @public
      * @method step
-     * @param  {Number} quantity Number of frames to loop through. If false, 
+     * @param  {Number} quantity Number of frames to loop through. If false,
      *                           Engine will loop indefinitely.
      */
     Engine.step = function step(quantity) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/famous/core",
   "devDependencies": {
     "grunt": "^0.4.4",
-    "grunt-eslint": "^0.4.0",
+    "grunt-eslint": "^0.5.0",
     "grunt-jscs-checker": "^0.4.1",
     "load-grunt-tasks": "^0.4.0",
     "time-grunt": "^0.3.1"


### PR DESCRIPTION
This pull requests makes a number of improvements to the Engine module. 

First, this takes advantage of the hi-resolution timer available in modern browsers.
http://updates.html5rocks.com/2012/05/requestAnimationFrame-API-now-with-sub-millisecond-precision

It also makes use of `requestID` returned by `requestAnimationFrame` and `cancelAnimationFrame`. This eliminates the need to maintain a `runLoop` flag and check that flag on every loop. This allows the call stack for `rAF` to be reduced to a single function call. 

This change will require an updated requestAnimationFrame shim, which I can add to Famous/polyfills if these changes are accepted.

The Engine now has `enable` and `disable` methods for turning the `rAF` loop on and off. This is a better API than setting an option.

The `step` function now allows you to give it a set number of frames to advance. This is useful for testing and debugging purposes. 

Lastly, there is `deregisterContext` method that removes a context from being evaluated by the `rAF` loop.

I would appreciate it if others would double check my work here, trying it out in their apps, to see if everything works correctly (since we don't yet have a test suite) and comment on these changes. 
