### PR TITLE
Add the "align" modifier property to Scene.js

### DIFF
--- a/Scene.js
+++ b/Scene.js
@@ -70,6 +70,7 @@ define(function(require, exports, module) {
         var transformDefinition = definition.transform;
         var opacity = definition.opacity;
         var origin = definition.origin;
+        var align = definition.align;
         var size = definition.size;
         var transform = Transform.identity;
         if (transformDefinition instanceof Array) {
@@ -90,6 +91,7 @@ define(function(require, exports, module) {
             transform: transform,
             opacity: opacity,
             origin: origin,
+            align: align,
             size: size
         });
         return result;


### PR DESCRIPTION
Scene.js was not updated to use the new "align" property of Modifiers. Not it is!
