### PR TITLE
Set y default for Transform.scale

### DIFF
--- a/Transform.js
+++ b/Transform.js
@@ -186,6 +186,7 @@ define(function(require, exports, module) {
      */
     Transform.scale = function scale(x, y, z) {
         if (z === undefined) z = 1;
+        if (y === undefined) y = x;
         return [x, 0, 0, 0, 0, y, 0, 0, 0, 0, z, 0, 0, 0, 0, 1];
     };
 


### PR DESCRIPTION
The issue is: if you forget to set the second argument, scale is not applied.

I trapped on this once, now on irc @markmarijnissen trapped on it.

Fix is trivial, we assume scale to function similar to css transform scale.
