### PR TITLE
[TWEAK] removeChild() not needed

### DIFF
--- a/ElementAllocator.js
+++ b/ElementAllocator.js
@@ -43,7 +43,7 @@ define(function(require, exports, module) {
         }
         else {
             while (oldContainer.hasChildNodes()) {
-                container.appendChild(oldContainer.removeChild(oldContainer.firstChild));
+                container.appendChild(oldContainer.firstChild);
             }
         }
 


### PR DESCRIPTION
The removal of the parent node can happen implicitly.
https://developer.mozilla.org/en-US/docs/Web/API/Node.appendChild
"If the node already exists it is removed from current parent node, then added to new parent node."
